### PR TITLE
Fix code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/src/services/safe-apps/manifest.ts
+++ b/src/services/safe-apps/manifest.ts
@@ -55,8 +55,16 @@ const getAppLogoUrl = (appUrl: string, { icons = [], iconPath = '' }: AppManifes
   return `${appUrl}${isRelativeUrl(iconUrl) ? '' : '/'}${iconUrl}`
 }
 
+const ALLOWED_DOMAINS = ['example.com', 'another-safe-domain.com']; // Add your allowed domains here
+
 const fetchAppManifest = async (appUrl: string, timeout = 5000): Promise<unknown> => {
   const normalizedUrl = trimTrailingSlash(appUrl)
+  const urlObj = new URL(normalizedUrl)
+
+  if (!ALLOWED_DOMAINS.includes(urlObj.hostname)) {
+    throw new Error(`The domain ${urlObj.hostname} is not allowed`)
+  }
+
   const manifestUrl = `${normalizedUrl}/manifest.json`
 
   // A lot of apps are hosted on IPFS and IPFS never times out, so we add our own timeout


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/3](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/3)

To fix the SSRF vulnerability, we should avoid using user input directly in the hostname of the URL. Instead, we can use an allow-list of known safe URLs or domains. This ensures that only pre-approved URLs can be used in the request, mitigating the risk of SSRF.

1. Create an allow-list of known safe URLs or domains.
2. Validate the `appUrl` against this allow-list before making the request.
3. If the `appUrl` is not in the allow-list, throw an error or handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
