### PR TITLE
Fix code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "react-papaparse": "^4.0.2",
     "react-redux": "^9.1.2",
     "semver": "^7.6.3",
-    "zodiac-roles-deployments": "^2.2.5"
+    "zodiac-roles-deployments": "^2.2.5",
+    "dompurify": "^3.1.7"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.1",

--- a/src/hooks/safe-apps/useSafeAppUrl.ts
+++ b/src/hooks/safe-apps/useSafeAppUrl.ts
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { sanitizeUrl } from '@/utils/url'
 import { useEffect, useMemo, useState } from 'react'
+import DOMPurify from 'dompurify'
 
 const useSafeAppUrl = (): string | undefined => {
   const router = useRouter()
@@ -11,7 +12,7 @@ const useSafeAppUrl = (): string | undefined => {
     setAppUrl(router.query.appUrl?.toString())
   }, [router])
 
-  return useMemo(() => (appUrl ? sanitizeUrl(appUrl) : undefined), [appUrl])
+  return useMemo(() => (appUrl ? DOMPurify.sanitize(sanitizeUrl(appUrl)) : undefined), [appUrl])
 }
 
 export { useSafeAppUrl }


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/2](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/2)

To fix the problem, we need to ensure that the `appUrl` is properly sanitized before being used as the `src` attribute of the `iframe` element. We can use a well-known library like `DOMPurify` to sanitize the URL.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the relevant files.
3. Use `DOMPurify` to sanitize the `appUrl` before using it in the `iframe` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
