### PR TITLE
Fix code scanning alert no. 1: Client-side URL redirect

### DIFF
--- a/src/hooks/safe-apps/useSafeAppUrl.ts
+++ b/src/hooks/safe-apps/useSafeAppUrl.ts
@@ -2,13 +2,24 @@ import { useRouter } from 'next/router'
 import { sanitizeUrl } from '@/utils/url'
 import { useEffect, useMemo, useState } from 'react'
 
+const AUTHORIZED_URLS = [
+  'https://trustedapp1.com',
+  'https://trustedapp2.com',
+  // Add more authorized URLs here
+]
+
 const useSafeAppUrl = (): string | undefined => {
   const router = useRouter()
   const [appUrl, setAppUrl] = useState<string | undefined>()
 
   useEffect(() => {
     if (!router.isReady) return
-    setAppUrl(router.query.appUrl?.toString())
+    const url = router.query.appUrl?.toString()
+    if (url && AUTHORIZED_URLS.includes(sanitizeUrl(url))) {
+      setAppUrl(url)
+    } else {
+      setAppUrl(undefined)
+    }
   }, [router])
 
   return useMemo(() => (appUrl ? sanitizeUrl(appUrl) : undefined), [appUrl])


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/1](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/1)

To fix the problem, we need to ensure that the `appUrl` is validated against a list of authorized URLs before it is used. This can be achieved by maintaining a list of allowed URLs and checking if the `appUrl` is in this list before setting it as the `src` attribute of the iframe.

1. Create a list of authorized URLs.
2. Modify the `useSafeAppUrl` hook to validate the `appUrl` against this list.
3. If the `appUrl` is not in the list, do not set it as the `src` attribute of the iframe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
