### PR TITLE
Revert "Chore(deps-dev): Bump @types/lodash from 4.17.13 to 4.17.16"

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@typechain/ethers-v6": "^0.5.1",
     "@types/jest": "^29.5.4",
     "@types/js-cookie": "^3.0.6",
-    "@types/lodash": "^4.17.16",
+    "@types/lodash": "^4.17.13",
     "@types/mdx": "^2.0.13",
     "@types/node": "22.8.1",
     "@types/qrcode": "^1.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6029,10 +6029,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.136", "@types/lodash@^4.14.167", "@types/lodash@^4.17.16":
-  version "4.17.16"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
-  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
+"@types/lodash@^4.14.136", "@types/lodash@^4.14.167", "@types/lodash@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.13.tgz#786e2d67cfd95e32862143abe7463a7f90c300eb"
+  integrity sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==
 
 "@types/long@^4.0.1":
   version "4.0.2"


### PR DESCRIPTION
Reverts Dargon789/safe-wallet-web#75

## Summary by Sourcery

Chores:
- Revert the update of the @types/lodash dependency.