### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/apps/web/src/services/safe-apps/manifest.ts
+++ b/apps/web/src/services/safe-apps/manifest.ts
@@ -1,6 +1,16 @@
 import type { AllowedFeatures, SafeAppDataWithPermissions } from '@/components/safe-apps/types'
 import { isRelativeUrl, trimTrailingSlash } from '@/utils/url'
 import { SafeAppAccessPolicyTypes } from '@safe-global/safe-gateway-typescript-sdk'
+const allowedDomains = ['example.com', 'another-example.com']
+
+const isValidAppUrl = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url)
+    return allowedDomains.some(domain => hostname.endsWith(domain))
+  } catch {
+    return false
+  }
+}
 
 type AppManifestIcon = {
   src: string
@@ -56,6 +66,9 @@ const getAppLogoUrl = (appUrl: string, { icons = [], iconPath = '' }: AppManifes
 }
 
 const fetchAppManifest = async (appUrl: string, timeout = 5000): Promise<unknown> => {
+  if (!isValidAppUrl(appUrl)) {
+    throw new Error('Invalid app URL')
+  }
   const normalizedUrl = trimTrailingSlash(appUrl)
   const manifestUrl = `${normalizedUrl}/manifest.json`
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/25](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/25)

To fix the SSRF vulnerability, we need to ensure that the `appUrl` is validated against a whitelist of allowed domains or patterns before constructing the `manifestUrl`. This can be achieved by implementing a validation function that checks if the `appUrl` matches a predefined set of allowed URLs or domains.

1. Create a list of allowed domains or patterns.
2. Implement a validation function that checks if the `appUrl` matches any of the allowed patterns.
3. Use this validation function before constructing the `manifestUrl` in the `fetchAppManifest` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixes a potential server-side request forgery vulnerability by validating the app URL against a whitelist of allowed domains.