### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/apps/web/src/services/safe-apps/manifest.ts
+++ b/apps/web/src/services/safe-apps/manifest.ts
@@ -56,9 +56,19 @@ const getAppLogoUrl = (appUrl: string, { icons = [], iconPath = '' }: AppManifes
 }
 
 const fetchAppManifest = async (appUrl: string, timeout = 5000): Promise<unknown> => {
+  // Define an allowlist of trusted base URLs
+  const trustedBaseUrls = ['https://trusted-domain1.com', 'https://trusted-domain2.com']
+
   // Strip URL parameters for fetching the manifest
   const baseUrl = stripUrlParams(appUrl)
   const normalizedUrl = trimTrailingSlash(baseUrl)
+
+  // Validate the normalized URL against the allowlist
+  const isTrustedUrl = trustedBaseUrls.some((trustedUrl) => normalizedUrl.startsWith(trustedUrl))
+  if (!isTrustedUrl) {
+    throw new Error(`Untrusted app URL: ${normalizedUrl}`)
+  }
+
   const manifestUrl = `${normalizedUrl}/manifest.json`
 
   // A lot of apps are hosted on IPFS and IPFS never times out, so we add our own timeout


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/25](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/25)

To fix the SSRF vulnerability, we need to validate and restrict the `appUrl` parameter to ensure it only points to trusted domains or paths. This can be achieved by implementing an allowlist of trusted base URLs and verifying that the `appUrl` matches one of these trusted URLs before constructing the `manifestUrl` and making the `fetch` request.

**Steps to fix:**
1. Introduce an allowlist of trusted base URLs in `fetchAppManifest`.
2. Validate the `appUrl` against this allowlist after stripping parameters and normalizing it.
3. If the `appUrl` does not match any trusted URL, throw an error and prevent the `fetch` request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enforce allowlist validation for external app URLs in fetchAppManifest to prevent SSRF vulnerabilities.

Bug Fixes:
- Prevent SSRF by validating and restricting the appUrl to a predefined allowlist before fetching the manifest.

Enhancements:
- Introduce allowlist of trusted base URLs, normalize URLs by stripping parameters and trailing slashes, and reject untrusted URLs with an error.