### PR TITLE
Potential fix for code scanning alert no. 62: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build next.js app
         uses: ./.github/actions/build
         with:
-          secrets: ${{ toJSON(secrets) }}
+          secrets: ${{ secrets.REQUIRED_SECRET }}
 
       - name: Analyze bundle
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/62](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/62)

To fix the issue, replace the use of `toJSON(secrets)` with explicit references to only the secrets required by the workflow. This ensures that only the necessary secrets are passed to the workflow runner, adhering to the principle of least privilege. Specifically, identify the secrets needed for the `build` step and reference them directly using `${{ secrets.SECRET_NAME }}`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict secrets exposure in the Next.js bundle analysis workflow by passing only the necessary secret to the build action instead of all available secrets.

Bug Fixes:
- Address code scanning alert by preventing exposure of all secrets in the GitHub Actions workflow.

Enhancements:
- Pass only the required secret to the build step rather than using toJSON(secrets) to serialize all secrets.