### PR TITLE
Potential fix for code scanning alert no. 80: Disabling certificate validation

### DIFF
--- a/apps/mobile/scripts/getCertificates.js
+++ b/apps/mobile/scripts/getCertificates.js
@@ -20,7 +20,7 @@ function getFullCertificateChain(hostname, port = 443) {
       hostname,
       port,
       method: 'HEAD',
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
     }
 
     const req = https.request(options, (res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/safe-wallet-web/security/code-scanning/80](https://github.com/Dargon789/safe-wallet-web/security/code-scanning/80)

General fix: do not disable TLS certificate validation. Remove `rejectUnauthorized: false` (or set it to `true`) so Node.js performs normal certificate verification.

Best minimal fix in `apps/mobile/scripts/getCertificates.js` (around lines 19–24): change the request options to enforce validation by setting `rejectUnauthorized: true`. This preserves existing functionality (fetching cert chains from valid TLS endpoints) while eliminating insecure behavior. No new methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Enable TLS certificate verification for HTTPS requests in the mobile getCertificates script instead of explicitly disabling it.